### PR TITLE
Session timeout

### DIFF
--- a/FSJ_django20_project/FSJ_django20_project/settings.py
+++ b/FSJ_django20_project/FSJ_django20_project/settings.py
@@ -40,7 +40,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django_filters',
-    'widget_tweaks'
+    'widget_tweaks',
 ]
 
 MIDDLEWARE = [
@@ -156,3 +156,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 MEDIA_URL = '/media/'
 
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+
+SESSION_COOKIE_AGE = 3600
+
+SESSION_SAVE_EVERY_REQUEST = True


### PR DESCRIPTION
Implemented basic session timeout.

Timeout time length can be modified in settings.py and changing "SESSION_COOKIE_AGE" to however long you want (in seconds)

Upon clicking a new link after session has timed out, user will be logged out. Upon logging back in, the user will be taken to the link they originally clicked on