### PR TITLE
fixed bug with applications being marked submitted without proper docs

### DIFF
--- a/FSJ_django20_project/FSJ/views_student.py
+++ b/FSJ_django20_project/FSJ/views_student.py
@@ -85,12 +85,12 @@ def student_addapplication(request, award_idnum):
                         
                 elif '_submit' in request.POST:
                     if not award.is_open():
-                        return redirect('home')
-                    application.is_submitted = True            
+                        return redirect('home')            
                     if award.documents_needed == True and not application.application_file:
                         messages.warning(request, 'Please upload a document.')
                     
                     else:
+                        application.is_submitted = True
                         application.student = FSJ_user
                         application.award = award
                         application.save()


### PR DESCRIPTION
Fixed bug where if a student submitted an application for an award that required documents but did not include documents, the application would be marked as "submitted" anyway.

This is a fix for [issue #144 ](https://github.com/CMPUT401FSJ/FSJAwards/issues/144)